### PR TITLE
Cambio API REE index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,9 +127,7 @@
     .then((response) => response.json())
     .then((data) => {
       // Obtener los datos de los precios de electricidad
-      var pricesData = data.included.find(
-        (item) => item.type === "PVPC (€/MWh)"
-      ).attributes.values;
+     const pricesData = data.included.find(item => item.type === 'PVPC').attributes.values;
 
       // Obtener la hora actual
       var currentHour = new Date().getHours();


### PR DESCRIPTION
Cambio para obtener los datos tal y como los ofrece ahora Red Eléctrica Española. 
Cambiar `const pricesData = data.included.find(item => item.type === 'PVPC (\u20ac/MWh)').attributes.values;` por `const pricesData = data.included.find(item => item.type === 'PVPC').attributes.values;`